### PR TITLE
setup rework / config / style

### DIFF
--- a/lua/neotime/config.lua
+++ b/lua/neotime/config.lua
@@ -1,0 +1,9 @@
+--- neotime.nvim/lua/neotime/config.lua created by DBTow
+
+local Config = {}
+
+Config.options = {
+	style = "default", -- "minimal" | "default" | "advanced"
+}
+
+return Config

--- a/lua/neotime/init.lua
+++ b/lua/neotime/init.lua
@@ -1,33 +1,17 @@
 -- /lua/neotime/init.lua created by DBTow
 
+local config = require("neotime.config")
 local ui = require("neotime.ui")
-
 local timer = require("neotime.timer")
 
 local M = {}
 
 function M.setup()
-	vim.api.nvim_create_user_command("NeotimeToggle", function()
-		ui.toggle_window()
-	end, {})
-end
 
-function M.start()
-	vim.api.nvim_create_user_command("StopwatchStart", function()
-		timer.start()
-	end, {})
-end
-
-function M.stop()
-	vim.api.nvim_create_user_command("StopwatchStop", function()
-		timer.stop()
-	end, {})
-end
-
-function M.reset()
-	vim.api.nvim_create_user_command("StopwatchReset", function()
-		timer.reset()
-	end, {})
+	vim.api.nvim_create_user_command("NeotimeToggle", ui.toggle_window, {})
+	vim.api.nvim_create_user_command("StopwatchStart", timer.start, {})
+	vim.api.nvim_create_user_command("StopwatchStop", timer.stop, {})
+	vim.api.nvim_create_user_command("StopwatchReset", timer.reset, {})
 end
 
 return M

--- a/lua/neotime/styles.lua
+++ b/lua/neotime/styles.lua
@@ -1,0 +1,42 @@
+--- neotime.nvim/lua/neotime/styles.lua created by DBTow
+
+local config = require("neotime.config")
+
+local M = {}
+
+
+-- Function to retrieve window style appearance from config and set window options accordingly
+function M.get_styles_config()
+	local style = config.options.style or "default"
+
+	if style == "minimal" then
+		return {
+			win_opts = {
+				width = 10,
+				height = 1,
+				title = "",
+			}
+
+		}
+	elseif style == "default" then
+		return {
+			win_opts = {
+				width = 20,
+				height = 2,
+				title = "Neotime",
+				title_pos = "center",
+			}
+		}
+	else
+		return {
+			win_opts = {
+				width = 20,
+				height = 2,
+				title = "Neotime",
+				title_pos = "center",
+			}
+		}
+	end
+end
+
+return M

--- a/lua/neotime/ui.lua
+++ b/lua/neotime/ui.lua
@@ -1,5 +1,8 @@
 -- /lua/neotime/ui.lua created by DBTow
 
+local styles = require("neotime.styles")
+local timer = require("neotime.timer")
+
 local M = {
 	buf = nil,
 	win = nil,
@@ -9,29 +12,28 @@ local M = {
 
 
 function M.show_window()
+	-- Grab the styles config option
+	local style_config = styles.get_styles_config()
+
 	-- Create buffer if it does not exist
 	M.buf = M.buf or vim.api.nvim_create_buf(false, true)
 
 	-- Set initial text content
-	vim.api.nvim_buf_set_lines(M.buf, 0, -1, true, {require('neotime.timer').get_time()})
+	vim.api.nvim_buf_set_lines(M.buf, 0, -1, true, {timer.get_time()})
 
 	-- Only create a window if not already visible
 	if not (M.win and vim.api.nvim_win_is_valid(M.win)) then
 
 		-- Window configuration options
-		local opts = {
+		local opts = vim.tbl_extend("force", {
 			relative = "editor",
-			width = 20,
-			height = 2,
 			col = vim.o.columns,
 			row = 0,
 			anchor = "NE",
 			style = "minimal",
 			focusable = false,
 			border = "rounded",
-			title = "Neotime",
-			title_pos = "center",
-		}
+		}, style_config.win_opts or {})
 		M.win = vim.api.nvim_open_win(M.buf, false, opts)
 		M.ui_visible = true
 	end

--- a/plugin/neotime.lua
+++ b/plugin/neotime.lua
@@ -1,10 +1,3 @@
--- Ensuring that this plugin is loaded successfully into the runtimepath with a print statement
--- In the config file for nvim_test: vim.opt.rpt:append("~/neovimPlugins/neotime.nvim/)
---print("neotime.nvim loaded")
+--- neotime.nvim/plugin/neotime.lua created by DBTow
 
 require("neotime").setup()
-
-require("neotime").start()
-require("neotime").stop()
-require("neotime").reset()
-


### PR DESCRIPTION
-Simplified the neotime.nvim/plugin/neotime.lua file so that it just calls the setup function

-In the init.lua I put all of the user commands into the setup() function so that they are available out the gate for the user. 
(The setup() function is called immediately in the /plugin/neotime.lua file making the user commands available)

I added two new files /lua/neotime/ styles.lua and config.lua

config.lua just returns an options table for right now we focused on the window style. Window styles include "default" and "minimal"

We will use the styles.lua as a place to generate the window content based on the user configuration options. Currently it retrieves the window style option  with the get_styles_config() function and that returns the desired window options for the minimal and default styles.

In ui.lua we imported some modules to local variables for conciseness
-timer -styles
and cleaned up existing require statements in the code

Then in the show_window() function we called the get_styles_config() function to retrieve the desired window styling options and then merged the table with the unconfigureable window options (stock options). This new table is then given to the open_win() function as the window options.